### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
-permissions:
-  contents: read
 
 on: [push, pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/anttikivi/anttikivi.github.io/security/code-scanning/1](https://github.com/anttikivi/anttikivi.github.io/security/code-scanning/1)

To fix the problem, an explicit `permissions:` block should be added to the workflow file. This can be done either at the top/root level (applies to all jobs), or individually to each job. The most effective and simplest solution is to add it at the top level, so that both `build` and `check` jobs inherit the minimal permissions. Since all steps operate only on code (install, build, lint), the least-privilege required is `contents: read`, which allows read access to the repository content. Edit the file `.github/workflows/ci.yml` and insert the following block after the `name: CI` line (i.e. before `on:`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or variables are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
